### PR TITLE
fix(Table): 修复表格行未全选时，表头checkbox不是半选中状态的问题

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -1084,17 +1084,20 @@ class Table<T extends IBaseObject = IBaseObject> extends React.Component<
   }
 
   /**
-   * 判断是否已全部选择
+   * 判断是否已选中，all or one
    */
-  public hasSelectedAll = () => {
+  public hasSelected = (mode: "all" | "one") => {
     const keys = this.getAvailableRowsKeys()
     const { dataSource } = this.props
     const { selectedRowKeys } = this.state
+
     if (
       dataSource &&
       dataSource.length &&
       keys.length &&
-      keys.every((key) => selectedRowKeys.includes(key))
+      (mode === "all"
+        ? keys.every((key) => selectedRowKeys.includes(key))
+        : keys.some((key) => selectedRowKeys.includes(key)))
     ) {
       return true
     }
@@ -1203,22 +1206,24 @@ class Table<T extends IBaseObject = IBaseObject> extends React.Component<
             })}
             key="functional-all"
           >
-            {selectMultiple && !!onSelectChange && (() => {
-              const hasSelectedAll = this.hasSelectedAll()
-              const hasSelectedOne = !!selectedRowKeys?.length
+            {selectMultiple &&
+              !!onSelectChange &&
+              (() => {
+                const hasSelectedAll = this.hasSelected("all")
+                const hasSelectedOne = this.hasSelected("one")
 
-              return (
-                <div className={`${prefix}-cell`}>
-                  <Checkbox
-                    disabled={!this.getAvailableRowsKeys().length}
-                    onChange={this.handleSelectAll}
-                    checked={hasSelectedAll}
-                    indeterminate={!hasSelectedAll && hasSelectedOne}
-                    className={`${prefix}-selectComponent`}
-                  />
-                </div>
-              )
-            })()}
+                return (
+                  <div className={`${prefix}-cell`}>
+                    <Checkbox
+                      disabled={!this.getAvailableRowsKeys().length}
+                      onChange={this.handleSelectAll}
+                      checked={hasSelectedAll}
+                      indeterminate={!hasSelectedAll && hasSelectedOne}
+                      className={`${prefix}-selectComponent`}
+                    />
+                  </div>
+                )
+              })()}
           </div>
         )}
         {columns.map((col, index) => {

--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -1203,16 +1203,22 @@ class Table<T extends IBaseObject = IBaseObject> extends React.Component<
             })}
             key="functional-all"
           >
-            {selectMultiple && !!onSelectChange && (
-              <div className={`${prefix}-cell`}>
-                <Checkbox
-                  disabled={!this.getAvailableRowsKeys().length}
-                  onChange={this.handleSelectAll}
-                  checked={this.hasSelectedAll()}
-                  className={`${prefix}-selectComponent`}
-                />
-              </div>
-            )}
+            {selectMultiple && !!onSelectChange && (() => {
+              const hasSelectedAll = this.hasSelectedAll()
+              const hasSelectedOne = !!selectedRowKeys?.length
+
+              return (
+                <div className={`${prefix}-cell`}>
+                  <Checkbox
+                    disabled={!this.getAvailableRowsKeys().length}
+                    onChange={this.handleSelectAll}
+                    checked={hasSelectedAll}
+                    indeterminate={!hasSelectedAll && hasSelectedOne}
+                    className={`${prefix}-selectComponent`}
+                  />
+                </div>
+              )
+            })()}
           </div>
         )}
         {columns.map((col, index) => {


### PR DESCRIPTION
修复表格行未全选时，表头checkbox不是半选中状态的问题
<img width="554" alt="wecom-temp-e60d165fd5e394e7d039ceecea620c29" src="https://user-images.githubusercontent.com/3615672/167992263-05b1875f-1186-4f47-b36d-d438d5763985.png">

