### PR TITLE
fix(Input): 修正Input在NumbericInput中使用时光标位置不稳定的问题

### DIFF
--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -2,9 +2,9 @@ import React, {
   forwardRef,
   useContext,
   useImperativeHandle,
-  useEffect,
   useRef,
   useState,
+  useLayoutEffect,
 } from "react"
 import PropTypes from "prop-types"
 import classNames from "classnames"
@@ -219,7 +219,17 @@ const Input: IInput = forwardRef(
           properties.result = value
         }
         if (element && element.value !== value && value) {
+          // 保存光标位置等后续恢复
+          const pos = element.selectionStart
+
           element.value = value
+
+          // 简单等待一个microtask，否则无法设置光标位置
+          // eslint-disable-next-line max-len
+          // see: https://github.com/zloirock/core-js/blob/master/packages/core-js/internals/microtask.js#LL46C61-L46C61
+          Promise.resolve().then(() => {
+            element.setSelectionRange(pos, pos)
+          })
         }
       }
     }
@@ -340,7 +350,7 @@ const Input: IInput = forwardRef(
       return Math.ceil(realLength)
     }
 
-    useEffect(() => {
+    useLayoutEffect(() => {
       updateElementsWidth()
       syncCleave()
     })


### PR DESCRIPTION
NumericInput的问题，在之前已经输入有数字的时候：
清空输入框，输入1位，光标再切换到最前面，再输入1位，按理应该光标在第一位后面，但是实际是在最后一位后面

除非与原有数字一样，比如原来是35，清空后，先输入5，再切到前面输入3，光标是对的

---
自测过，没有发现问题；但可能需要更多测试