### PR TITLE
fix(DatePicker): 尝试修复 DatePicker visible 的相关问题

### DIFF
--- a/components/date-picker/DatePicker.tsx
+++ b/components/date-picker/DatePicker.tsx
@@ -4,6 +4,7 @@ import React, {
   forwardRef,
   useContext,
   useImperativeHandle,
+  useEffect,
   useRef,
   useState,
 } from "react"
@@ -247,6 +248,17 @@ const DatePicker: IDatePicker = forwardRef(
     const { size: sizeContext } = useContext(ConfigContext)
     const size = getComputedSize(sizeProp, sizeContext)
 
+    useEffect(() => {
+      if (inputRef.current) {
+        const wrapper = inputRef.current.wrapper as HTMLDivElement
+        if (wrapper) {
+          wrapper.addEventListener("click", (e) => {
+            e.stopPropagation()
+          })
+        }
+      }
+    }, [])
+
     const classSet = classNames(
       className,
       `${prefix}-dateBase`,
@@ -264,25 +276,20 @@ const DatePicker: IDatePicker = forwardRef(
     }
 
     const handleVisibleChange = (bool: boolean) => {
-      const { input: inputElement } = inputRef.current || {}
       if (disabled) {
         return
       }
-      setTimeout(() => {
-        const { activeElement } = document
-        if (bool || (!bool && inputElement !== activeElement)) {
-          const newVal = convertDateToString(selectedDay)
-          if (!bool && value !== newVal) {
-            setValue(newVal)
-          }
-          if (onVisibleChange) {
-            onVisibleChange(bool)
-          }
-          if (visibleProp === null) {
-            setVisible(bool)
-          }
-        }
-      }, 0)
+
+      const newVal = convertDateToString(selectedDay)
+      if (!bool && value !== newVal) {
+        setValue(newVal)
+      }
+      if (onVisibleChange) {
+        onVisibleChange(bool)
+      }
+      if (visibleProp === null) {
+        setVisible(bool)
+      }
     }
 
     const handleDayClick = (
@@ -464,7 +471,7 @@ const DatePicker: IDatePicker = forwardRef(
               onMouseLeave={() => {
                 setClearIconState("out")
               }}
-              onClick={(e) => {
+              onMouseDown={(e) => {
                 if (value) {
                   e.stopPropagation()
                   if (valueProp === null) {
@@ -487,7 +494,12 @@ const DatePicker: IDatePicker = forwardRef(
               }}
             />
           ) : (
-            <Icon icon="calendar-outlined" />
+            <Icon
+              icon="calendar-outlined"
+              onMouseDown={() => {
+                handleVisibleChange(!visible)
+              }}
+            />
           )
         }
         size={size}

--- a/components/date-picker/RangePicker.tsx
+++ b/components/date-picker/RangePicker.tsx
@@ -4,6 +4,7 @@
 import React, {
   forwardRef,
   useContext,
+  useEffect,
   useImperativeHandle,
   useMemo,
   useRef,
@@ -272,6 +273,17 @@ const RangePicker: React.ForwardRefExoticComponent<
     const { size: sizeContext } = useContext(ConfigContext)
     const size = getComputedSize(sizeProp, sizeContext)
 
+    useEffect(() => {
+      if (inputRef.current) {
+        const wrapper = inputRef.current.wrapper as HTMLDivElement
+        if (wrapper) {
+          wrapper.addEventListener("click", (e) => {
+            e.stopPropagation()
+          })
+        }
+      }
+    }, [])
+
     const classSet = classNames(
       className,
       `${prefix}-rangeBase`,
@@ -321,35 +333,30 @@ const RangePicker: React.ForwardRefExoticComponent<
     }
 
     const handleVisibleChange = (bool: boolean) => {
-      const { input: inputElement } = inputRef.current || {}
       if (disabled) {
         return
       }
-      setTimeout(() => {
-        const { activeElement } = document
-        if (bool || (!bool && inputElement !== activeElement)) {
-          const newVal = convertDateRangeToString([from, to])
-          if (!bool) {
-            if (!to) {
-              if (newVal) {
-                const rangeReset = rangeValue.split(" - ")
-                setTimeout(() => {
-                  setFrom(new Date(rangeReset[0]))
-                  setTo(new Date(rangeReset[1]))
-                }, 250)
-              }
-            } else if (rangeValue !== newVal) {
-              setRangeValue(newVal)
-            }
+
+      const newVal = convertDateRangeToString([from, to])
+      if (!bool) {
+        if (!to) {
+          if (newVal) {
+            const rangeReset = rangeValue.split(" - ")
+            setTimeout(() => {
+              setFrom(new Date(rangeReset[0]))
+              setTo(new Date(rangeReset[1]))
+            }, 250)
           }
-          if (onVisibleChange) {
-            onVisibleChange(bool)
-          }
-          if (visibleProp === null) {
-            setVisible(bool)
-          }
+        } else if (rangeValue !== newVal) {
+          setRangeValue(newVal)
         }
-      }, 0)
+      }
+      if (onVisibleChange) {
+        onVisibleChange(bool)
+      }
+      if (visibleProp === null) {
+        setVisible(bool)
+      }
     }
 
     const isSelectingFirstDay = (
@@ -632,7 +639,7 @@ const RangePicker: React.ForwardRefExoticComponent<
               onMouseLeave={() => {
                 setClearIconState("out")
               }}
-              onClick={(e) => {
+              onMouseDown={(e) => {
                 if (rangeValue) {
                   e.stopPropagation()
                   if (valueProp === null) {
@@ -656,7 +663,12 @@ const RangePicker: React.ForwardRefExoticComponent<
               }}
             />
           ) : (
-            <Icon icon="calendar-outlined" />
+            <Icon
+              icon="calendar-outlined"
+              onMouseDown={() => {
+                handleVisibleChange(!visible)
+              }}
+            />
           )
         }
         size={size}

--- a/components/icon/Icon.tsx
+++ b/components/icon/Icon.tsx
@@ -33,6 +33,10 @@ export interface IIconProps {
    */
   onClick?: ((e: React.MouseEvent<SVGSVGElement, MouseEvent>) => void) | null
   /**
+   * onMouseDown 的 handler
+   */
+  onMouseDown?: (e: React.MouseEvent<SVGSVGElement, MouseEvent>) => void
+  /**
    * 自定义图标 path 路径
    */
   paths?: string[]
@@ -140,6 +144,10 @@ Icon.propTypes = {
    */
   onClick: PropTypes.func,
   /**
+   * onMouseDown 的 handler
+   */
+  onMouseDown: PropTypes.func,
+  /**
    * 自定义图标 path 路径
    */
   paths: PropTypes.array,
@@ -155,6 +163,7 @@ Icon.defaultProps = {
   icon: undefined,
   interactive: false,
   onClick: null,
+  onMouseDown: undefined,
   paths: undefined,
   size: 18,
 }

--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -368,6 +368,7 @@ const Input: IInput = forwardRef(
     useImperativeHandle(ref, () => {
       const realRef = inputRef?.current || cleaveRef?.current?.element
       return {
+        wrapper: wrapperElementRef?.current,
         cleave: cleaveRef?.current,
         input: realRef,
         leftElement: leftElementRef?.current,


### PR DESCRIPTION
回想了一下最初引入 `document.activeElement` 的原因：

问题：用户可能在 Input 内通过点击来移动光标位置以编辑日期，但 Input 内的点击会来回 toggle Popover 的 visible，这时就需要判断如果是 input focus 的情况下，则不设置 visible 为 false。

解决：rc-trigger 当然考虑过这样的场景，他们会提供 `trigger='focus'`，来适配 input，但是 adui 的 Input 外层其实是 div，所以这里还是自己通过 `!bool && inputElement !== activeElement` 来试图取巧地解决这个问题。

---

这次看了下代码，发现这样的实现还是有问题的，最大的问题是 input focus 的时候会触发一次 visible 变化，而因为 `trigger='click'` 的设计又会触发一次。visible 的逻辑有一点重合。

思路是 DatePicker 尽量接管 visible 逻辑：
1. 在 useEffect 中手动添加了阻止 click 冒泡的逻辑，使得 Popover 所添加的监听失效；
2. 保留 Input 在 focus blur 时控制 visible 的逻辑；
3. 将 Icon 的 click 事件换成 mousedown，这一点对体验有一些影响；
4. 最后，Popover 自身其实只负责处理点击其他元素将 visible 设置为 false 的逻辑，不干涉设置为 true 的逻辑。


